### PR TITLE
build.have_clang() no longer deadlocks on call; Fixes #8

### DIFF
--- a/llvmmath/build.py
+++ b/llvmmath/build.py
@@ -13,7 +13,7 @@ from distutils import sysconfig
 from functools import partial
 from collections import namedtuple
 from os.path import join, dirname, abspath, exists
-from subprocess import call, check_call, PIPE
+from subprocess import call, check_call
 
 from .utils import cached
 from .generator import generate_config
@@ -125,7 +125,9 @@ def have_llvm_asm():
 def have_clang():
     "See whether we have clang installed and working"
     try:
-        return call(['clang', '--help'], stdout=PIPE) == 0
+        # http://stackoverflow.com/questions/699325
+        with open(os.devnull, 'w') as devnull:
+            return call(['clang', '--help'], stdout=devnull, stderr=devnull) == 0
     except EnvironmentError:
         return False
 


### PR DESCRIPTION
`have_clang()` uses `subprocess.call()` and pipes `stdin`.  But `call()`
creates a `Popen` object and calls `wait()` on it.  The python docs specify
that `wait()` can deadlock if there is a lot of output piped to `stdout` without
anything reading from it.  By sending the output to `/dev/null`, the deadlock
will not occur.
