### PR TITLE
Update to new llvm interface

### DIFF
--- a/llvmmath/complex_support.py
+++ b/llvmmath/complex_support.py
@@ -92,11 +92,11 @@ def create_val2ref_wrapper(wrapped, name, func_ty):
     bb = lfunc.append_basic_block('entry')
     b = lc.Builder.new(bb)
 
-    ret = b.alloca(func_ty.return_type, 'result')
+    ret = b.alloca(func_ty.return_type, None, 'result')
 
     newargs = []
     for arg, dst_argty in zip(lfunc.args, dst_argtys):
-        dstarg = b.alloca(arg.type, 'arg')
+        dstarg = b.alloca(arg.type, None, 'arg')
         b.store(arg, dstarg)
         newargs.append(b.bitcast(dstarg, dst_argty))
 


### PR DESCRIPTION
This change is needed in order for llvmmath to build in an up to date Debian. See:

http://anonscm.debian.org/gitweb/?p=collab-maint/llvmmath.git;f=debian/patches/0001-Update-to-new-llvm-interface.patch
